### PR TITLE
GAE uses parameters to create body instead of query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.kloudless</groupId>
   <artifactId>kloudless-java</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <name>kloudless-java</name>
   <url>https://github.com/kloudless/kloudless-java</url>
   <dependencies>

--- a/src/main/java/com/kloudless/net/APIResource.java
+++ b/src/main/java/com/kloudless/net/APIResource.java
@@ -613,13 +613,18 @@ public abstract class APIResource extends KloudlessObject {
 				//look at createQuery.
 				requestClass.getDeclaredMethod("setPayload", byte[].class)
 						.invoke(request, GSON.toJson(params).getBytes());
+				extraHeaders.put("Content-Type", String
+						.format("application/json;charset=%s",
+								CHARSET));
 
 			} else {
 				requestClass.getDeclaredMethod("setPayload", byte[].class)
 						.invoke(request, query.getBytes());
 			}
 
-			for (Map.Entry<String, String> header : getHeaders(apiKey).entrySet()) {
+			Map<String, String> finalHeaders = getHeaders(apiKey);
+			finalHeaders.putAll(extraHeaders);
+			for (Map.Entry<String, String> header : finalHeaders.entrySet()) {
 				Class<?> httpHeaderClass = Class
 						.forName("com.google.appengine.api.urlfetch.HTTPHeader");
 				Object reqHeader = httpHeaderClass.getDeclaredConstructor(


### PR DESCRIPTION
Related to a support email recently sent.

Took a stab at making the GAE requests accept a parameter map for constructing a JSON body for POST requests.

Also fixed a potential problem where there could only ever be one Key Value for a header instead of many.
